### PR TITLE
Refresh access tokens when preparing the service

### DIFF
--- a/Withings.gs
+++ b/Withings.gs
@@ -34,6 +34,9 @@ function check_service(){
       'NEED AUTHENTICATION: Google App Script for Withings API', msg);          
     throw new Error(msg);                                                       
   }                                                                             
+  // Access tokens expire after 3 hours, refresh it now
+  // https://developer.withings.com/developer-guide/v3/integration-guide/dropship-cellular/get-access/access-and-refresh-tokens/
+  refresh(service);
   Logger.log('Service is authorized.')                                          
 }     
 


### PR DESCRIPTION
Hey there, was having issues where recurring jobs would stop working after a time - looked in the docs and the access_token expires after 3 hours.
Changed the check_service function to refresh the token - might not be the best place but thought this was a good way of letting you know.
My recurring jobs now run fine